### PR TITLE
Fix NullPointerException with palettes

### DIFF
--- a/common/src/main/java/com/kekecreations/arts_and_crafts/common/util/PaintbrushUtils.java
+++ b/common/src/main/java/com/kekecreations/arts_and_crafts/common/util/PaintbrushUtils.java
@@ -53,7 +53,7 @@ public class PaintbrushUtils {
         PaintbrushPalette palette = optionalPalette.get();
         Holder<Block> holder = palette.mappings().get(stack.getItemHolder());
 
-        if (holder.unwrapKey().isEmpty()) return null;
+        if (holder == null || holder.unwrapKey().isEmpty()) return null;
         
         return access.registryOrThrow(Registries.BLOCK).getOrThrow(holder.unwrapKey().get());
     }


### PR DESCRIPTION
Fixes a NullPointerException when painting a block that does not have a mapping for the used brush. Useful for cases where, for example, a mod adds a dyed set of blocks but no undyed variant, meaning there would be no corresponding bleachdew brush mapping.